### PR TITLE
requirements.txt: Add "click" as a dependency

### DIFF
--- a/py-wacz/requirements.txt
+++ b/py-wacz/requirements.txt
@@ -5,4 +5,5 @@ boilerpy3>=1.0.2
 pytest-cov>=2.10.1
 PyYAML>=5.3.1
 black>=20.8b1
+click>=7.1.1,<7.2.0
 jsonlines


### PR DESCRIPTION
The build process for `wacz` currently fails on the `master` branch because it fetches latest pre-release of `click` even though the dependency `typer` is only compatible with stable versions of it.

```
Processing dependencies for wacz==0.3.0b0
error: click 8.0.0rc1 is installed but click<7.2.0,>=7.1.1 is required by {'typer'}
```

This pull request resolves this build error by adding `click` as a dependency in `requirements.txt` with the version constraints requested by `typer`.