### PR TITLE
Fix http->https check + support for splitting page list by seed/non-seed

### DIFF
--- a/py-wacz/setup.py
+++ b/py-wacz/setup.py
@@ -2,7 +2,7 @@
 # vim: set sw=4 et:
 from setuptools import setup, find_packages
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 
 def load_requirements(filename):

--- a/py-wacz/tests/fixtures/test-extra-pages.jsonl
+++ b/py-wacz/tests/fixtures/test-extra-pages.jsonl
@@ -1,2 +1,0 @@
-{"url": "https://www.iana.org/about"}
-{"url": "https://www.iana.org/protocols"}

--- a/py-wacz/tests/test_create_wacz_indexing.py
+++ b/py-wacz/tests/test_create_wacz_indexing.py
@@ -96,6 +96,12 @@ class TestWaczIndexing(unittest.TestCase):
 
     def test_warc_with_extra_pages(self):
         with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "test-extra-pages.jsonl"), "wt") as fh:
+                fh.write("""\
+{"url": "https://www.iana.org/about"}
+{"url": "https://www.iana.org/protocols"}\
+""")
+
             self.assertEqual(
                 main(
                     [
@@ -105,7 +111,7 @@ class TestWaczIndexing(unittest.TestCase):
                         "-o",
                         os.path.join(tmpdir, "test-extra-pages.wacz"),
                         "-e",
-                        os.path.join(TEST_DIR, "test-extra-pages.jsonl"),
+                        os.path.join(tmpdir, "test-extra-pages.jsonl"),
                         "--detect-pages",
                     ]
                 ),
@@ -139,6 +145,70 @@ class TestWaczIndexing(unittest.TestCase):
                         "pages/pages.jsonl",
                     ],
                 )
+
+    def test_warc_with_extra_pages_via_seeds(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "pages.jsonl"), "wt") as fh:
+                fh.write("""\
+{"url": "https://example.com/", "seed": true}
+{"url": "https://www.iana.org/about"}
+{"url": "https://www.iana.org/protocols"}\
+""")
+
+            self.assertEqual(
+                main(
+                    [
+                        "create",
+                        "-f",
+                        os.path.join(TEST_DIR, "example-iana.warc"),
+                        "-o",
+                        os.path.join(tmpdir, "test-extra-pages.wacz"),
+                        "-p",
+                        os.path.join(tmpdir, "pages.jsonl"),
+                        "--split-seeds",
+                    ]
+                ),
+                0,
+            )
+
+            self.assertEqual(
+                main(
+                    [
+                        "validate",
+                        "-f",
+                        os.path.join(tmpdir, "test-extra-pages.wacz"),
+                    ]
+                ),
+                0,
+            )
+
+            with zipfile.ZipFile(os.path.join(tmpdir, "test-extra-pages.wacz")) as zf:
+                filelist = sorted(zf.namelist())
+
+                # verify pages file added for each list
+                self.assertEqual(
+                    filelist,
+                    [
+                        "archive/example-iana.warc",
+                        "datapackage-digest.json",
+                        "datapackage.json",
+                        "indexes/index.cdx.gz",
+                        "indexes/index.idx",
+                        "pages/extraPages.jsonl",
+                        "pages/pages.jsonl",
+                    ],
+                )
+
+                with zf.open("pages/extraPages.jsonl", "r") as fh:
+                    data = fh.read()
+                    self.assertTrue(b"https://www.iana.org/about" in data)
+                    self.assertTrue(b"https://www.iana.org/protocols" in data)
+
+                with zf.open("pages/pages.jsonl", "r") as fh:
+                    data = fh.read()
+                    self.assertTrue(b"https://example.com/" in data)
+
+
 
     def test_warc_resource_record(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/py-wacz/tests/test_create_wacz_indexing.py
+++ b/py-wacz/tests/test_create_wacz_indexing.py
@@ -10,17 +10,17 @@ TEST_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "fixtures")
 
 
 class TestWaczIndexing(unittest.TestCase):
-    def test_check_http_and_https_fail(self):
+    def test_check_http_and_https_changed(self):
         pages_dict = {"https://www.example.org/": "1db0ef709a"}
         check_url = "http://www.example.org/"
-        match = check_http_and_https(check_url, pages_dict)
-        self.assertEqual(match, True)
+        match = check_http_and_https(check_url, "", pages_dict)
+        self.assertEqual(match, "https://www.example.org/")
 
-    def test_check_http_and_https_success(self):
+    def test_check_http_and_https_not_found(self):
         pages_dict = {"https://www.example.org/": "1db0ef709a"}
         check_url = "http://fake"
-        match = check_http_and_https(check_url, pages_dict)
-        self.assertEqual(match, False)
+        match = check_http_and_https(check_url, "", pages_dict)
+        self.assertEqual(match, "")
 
     def test_warc_with_other_metadata(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/py-wacz/tests/test_create_wacz_indexing.py
+++ b/py-wacz/tests/test_create_wacz_indexing.py
@@ -97,10 +97,12 @@ class TestWaczIndexing(unittest.TestCase):
     def test_warc_with_extra_pages(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "test-extra-pages.jsonl"), "wt") as fh:
-                fh.write("""\
+                fh.write(
+                    """\
 {"url": "https://www.iana.org/about"}
 {"url": "https://www.iana.org/protocols"}\
-""")
+"""
+                )
 
             self.assertEqual(
                 main(
@@ -149,11 +151,13 @@ class TestWaczIndexing(unittest.TestCase):
     def test_warc_with_extra_pages_via_seeds(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             with open(os.path.join(tmpdir, "pages.jsonl"), "wt") as fh:
-                fh.write("""\
+                fh.write(
+                    """\
 {"url": "https://example.com/", "seed": true}
 {"url": "https://www.iana.org/about"}
 {"url": "https://www.iana.org/protocols"}\
-""")
+"""
+                )
 
             self.assertEqual(
                 main(
@@ -207,8 +211,6 @@ class TestWaczIndexing(unittest.TestCase):
                 with zf.open("pages/pages.jsonl", "r") as fh:
                     data = fh.read()
                     self.assertTrue(b"https://example.com/" in data)
-
-
 
     def test_warc_resource_record(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/py-wacz/wacz/main.py
+++ b/py-wacz/wacz/main.py
@@ -65,6 +65,8 @@ def main(args=None):
         help="Allows the user to specify the hash type used. Currently we allow sha256 and md5",
     )
 
+    create.add_argument("--split-seeds", action="store_true")
+
     create.add_argument("--ts")
     create.add_argument("--url")
     create.add_argument("--date")
@@ -200,6 +202,7 @@ def create_wacz(res):
             detect_pages=res.detect_pages,
             passed_pages_dict=passed_pages_dict,
             extract_text=res.text,
+            split_seeds=res.split_seeds,
         )
 
         wacz_indexer.process_all()
@@ -265,6 +268,18 @@ def create_wacz(res):
                 has_text=wacz_indexer.has_text,
             ),
         )
+
+        if len(wacz_indexer.extra_pages) > 0:
+            wacz_indexer.write_page_list(
+                wacz,
+                EXTRA_PAGES_INDEX,
+                wacz_indexer.serialize_json_pages(
+                    wacz_indexer.extra_pages.values(),
+                    id="extra-pages",
+                    title="Extra Pages",
+                    has_text=wacz_indexer.has_text,
+                ),
+            )
 
     if len(wacz_indexer.extra_page_lists) > 0:
         print("Generating extra page lists...")

--- a/py-wacz/wacz/util.py
+++ b/py-wacz/wacz/util.py
@@ -14,10 +14,10 @@ def check_http_and_https(url, pages_dict):
     """
     url_body = url.split(":")[1]
     if f"http:{url_body}" in pages_dict:
-        return True
+        return f"http:{url_body}"
     if f"https:{url_body}" in pages_dict:
-        return True
-    return False
+        return f"https:{url_body}"
+    return ""
 
 
 def get_py_wacz_version():

--- a/py-wacz/wacz/waczindexer.py
+++ b/py-wacz/wacz/waczindexer.py
@@ -185,10 +185,9 @@ class WACZIndexer(CDXJIndexer):
         if id_ in self.passed_pages_dict:
             matched_id = id_
 
-        if check_http_and_https(url, self.passed_pages_dict):
-            matched_id = url
+        matched_id = check_http_and_https(url, self.passed_pages_dict)
         # If we find a match build a record
-        if matched_id != "":
+        if matched_id:
             self.pages[matched_id] = {"timestamp": ts, "url": url, "title": url}
             # Add title and text if they've been provided
             if "title" in self.passed_pages_dict[matched_id]:

--- a/py-wacz/wacz/waczindexer.py
+++ b/py-wacz/wacz/waczindexer.py
@@ -26,6 +26,7 @@ class WACZIndexer(CDXJIndexer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.pages = {}
+        self.extra_pages = {}
         self.extra_page_lists = {}
         self.title = ""
         self.desc = ""
@@ -39,6 +40,7 @@ class WACZIndexer(CDXJIndexer):
             self.hash_type = "sha256"
 
         self.passed_pages_dict = kwargs.pop("passed_pages_dict", {})
+        self.split_seeds = kwargs.pop("split_seeds", False)
 
         if self.main_url != None and self.main_url != "":
             self.main_url_flag = False
@@ -182,22 +184,27 @@ class WACZIndexer(CDXJIndexer):
         matched_id = ""
         # Check for both a matching url/ts and url entry
 
-        if id_ in self.passed_pages_dict:
-            matched_id = id_
+        # if id_ in self.passed_pages_dict:
+        #    matched_id = id_
 
-        matched_id = check_http_and_https(url, self.passed_pages_dict)
+        matched_id = check_http_and_https(url, ts, self.passed_pages_dict)
         # If we find a match build a record
         if matched_id:
-            self.pages[matched_id] = {"timestamp": ts, "url": url, "title": url}
+            new_page = {"timestamp": ts, "url": url, "title": url}
+            input_page = self.passed_pages_dict[matched_id]
+
             # Add title and text if they've been provided
-            if "title" in self.passed_pages_dict[matched_id]:
-                self.pages[matched_id]["title"] = self.passed_pages_dict[matched_id][
-                    "title"
-                ]
+            if "title" in input_page:
+                new_page["title"] = input_page["title"]
             if "text" in self.passed_pages_dict[matched_id]:
-                self.pages[matched_id]["text"] = self.passed_pages_dict[matched_id][
-                    "text"
-                ]
+                new_page["text"] = input_page["text"]
+
+            if self.split_seeds and not input_page.get("seed"):
+                self.extra_pages[matched_id] = new_page
+                print("EXTRA", url)
+            else:
+                self.pages[matched_id] = new_page
+
             # Delete the entry from our pages_dict so we can't match it again
             del self.passed_pages_dict[matched_id]
 


### PR DESCRIPTION
Fixes the http/https check for also select the correct url for page.

Allow splitting seeds from non-seeds, where seeds go into pages.jsonl, non-seeds into extraPages.jsonl